### PR TITLE
Bytt font i List of Figures och List of Tables

### DIFF
--- a/miunthesis.cls
+++ b/miunthesis.cls
@@ -293,3 +293,7 @@
 \renewcommand{\cftsecpagefont}{\sffamily}
 \renewcommand{\cftsubsecpagefont}{\sffamily}
 \renewcommand{\cftsubsubsecpagefont}{\sffamily}
+
+%% List of Figures, Tables
+\renewcommand{\cftloftitlefont}{\large\bfseries\sffamily}
+\renewcommand{\cftlottitlefont}{\large\bfseries\sffamily}


### PR DESCRIPTION
Fick feedback att fonten för figur och tabell kapitel ska vara sans-serif. Dessa rader fixar det problemet genom att sätta fonten detsamma som andra kapitelfonter

Innan:
![image](https://user-images.githubusercontent.com/43440295/172370375-c15c048a-8e7d-4832-9389-7192aa47c649.png)
![image](https://user-images.githubusercontent.com/43440295/172370421-53e958f9-597d-4f79-a6b6-c95401a067b3.png)

Efter:
![image](https://user-images.githubusercontent.com/43440295/172370502-5c2e69d4-a965-4486-822f-1dbbe9414d7c.png)
![image](https://user-images.githubusercontent.com/43440295/172370531-0c438156-6e53-43cc-83e3-fdd484d2815f.png)

Möjligtvis att fonten för 'Contents' och 'List of Algorithms' behöver också fixas